### PR TITLE
✨ Added the post deletion.

### DIFF
--- a/PostAPI.go
+++ b/PostAPI.go
@@ -147,6 +147,24 @@ func (post *Post) Create(ctx *aero.Context) error {
 	return nil
 }
 
+// Delete deletes the post from the database.
+func (post *Post) Delete() error {
+	thread, threadErr := GetThread(post.ThreadID)
+
+	if threadErr != nil {
+		return errors.New("Thread does not exist")
+	}
+
+	// Remove the reference of the post in the thread tha contain it
+	if !thread.Remove(post.ID) {
+		return errors.New("This post does not exist in the thread")
+	}
+	thread.Save()
+
+	DB.Delete("Post", post.ID)
+	return nil
+}
+
 // AfterEdit updates the date it has been edited.
 func (post *Post) AfterEdit(ctx *aero.Context) error {
 	post.Edited = DateTimeUTC()

--- a/PostAPI.go
+++ b/PostAPI.go
@@ -159,6 +159,7 @@ func (post *Post) Delete() error {
 	if !thread.Remove(post.ID) {
 		return errors.New("This post does not exist in the thread")
 	}
+
 	thread.Save()
 
 	DB.Delete("Post", post.ID)

--- a/Thread.go
+++ b/Thread.go
@@ -170,3 +170,15 @@ func (thread *Thread) Unlike(userID string) {
 		}
 	}
 }
+
+// Remove post from the post list.
+func (thread *Thread) Remove(postID string) bool {
+	for index, item := range thread.Posts {
+		if item == postID {
+			thread.Posts = append(thread.Posts[:index], thread.Posts[index+1:]...)
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR should close#43

By deleting a post by using the _PostAPI_ we also delete its reference in
the thread that contains it since we don't want to have a ghost post in a
thread.

We get this container thread by using the **ThreadID** present in a Post. We then
go through all the **PostsID** and **delete** the one that possesses the *same
ID* that the Post we firstly intend to **delete**.
Finally, we **save** these changes in the thread otherwise this deletion would
not be effective.