### PR TITLE
✨ Added support for mention on a forum post.

### DIFF
--- a/Utils.go
+++ b/Utils.go
@@ -27,6 +27,10 @@ var (
 	stripTagsRegex = regexp.MustCompile(`<[^>]*>`)
 	sourceRegex    = regexp.MustCompile(`\(Source: (.*?)\)`)
 	writtenByRegex = regexp.MustCompile(`\[Written by (.*?)\]`)
+	// Regex to find @userNickname
+	mentionIDRegex = regexp.MustCompile(`(^|[\s])(<@[\w]+>)`)
+	// Regex to find <@userID>
+	mentionNickRegex = regexp.MustCompile(`(?:[^\S]|^)(@[\w]+)`)
 )
 
 // GenerateID generates a unique ID for a given table.
@@ -306,4 +310,13 @@ func PanicOnError(err error) {
 func PrettyPrint(obj interface{}) {
 	pretty, _ := json.MarshalIndent(obj, "", "\t")
 	fmt.Println(string(pretty))
+}
+
+// ReplaceMention look for any whole src in postText and replace them by repl
+func TransformIDToMention(src string, postText string, repl string) string {
+	// Regex to replace a whole word so if we're looking to replace @Scott, @Scotttt would not be matched
+	re := regexp.MustCompile(`(^|[^\p{L}0-9_])` + regexp.QuoteMeta(src) + `([^\p{L}0-9_]|$)`)
+	// Replace <@userID> by the markdown link [@userNickname](userLink)
+	postText = re.ReplaceAllString(postText, repl)
+	return postText
 }


### PR DESCRIPTION
What I do is when the user saves a new post I change `@Scott` into `<@VJOK1ckvx>` and then when we call `Post.Html()` I look for any `<@userID>` and change them into `[@userNick](userLink)`. It should prevent any problem if the user changes its nickname and always render the current one.

I'm not good with regular expressions so they might be improved.

One remaining issue with the current pull request is that if the user tries to edit a post with a mention, he will see the mention in its pure form like `<@userID>` whereas what we would want him to see should be `@userNickname`. This issue is caused by the call of [`post.Text()`](https://github.com/animenotifier/notify.moe/blob/go/mixins/Postable.pixy#L16)